### PR TITLE
update paths to truetype fonts in tests

### DIFF
--- a/t/font-synfont.t
+++ b/t/font-synfont.t
@@ -9,6 +9,7 @@ use PDF::Builder;
 
 my @possible_locations = (
     '/usr/share/fonts/truetype/ttf-dejavu/DejaVuSans.ttf',
+    '/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf',
     '/var/lib/defoma/gs.d/dirs/fonts/DejaVuSans.ttf',
     'C:/Windows/fonts/DejaVuSans.ttf',
 );

--- a/t/font-ttf.t
+++ b/t/font-ttf.t
@@ -9,7 +9,7 @@ use PDF::Builder;
 
 my @possible_locations = (
     '/usr/share/fonts/truetype/ttf-dejavu/DejaVuSans.ttf',
-    '/usr/share/fonts/truetype/ttf-dejavu/DejaVuSans.ttf',
+    '/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf',
     'C:/Windows/fonts/DejaVuSans.ttf',
 );
 


### PR DESCRIPTION

In Debian we are currently applying the following patch to
PDF-Builder.
We thought you might be interested in it too.

    Description: update paths to truetype fonts in tests
     At least in Debian, /usr/share/fonts/truetype/ttf-dejavu/DejaVuSans.ttf (in
     the transitional package ttf-dejavu-core) is just a symlink to
     /usr/share/fonts/truetype/dejavu/DejaVuSans.ttf (in the "real" package
     fonts-dejavu-core). When only fonts-dejavu-core is installed, the font file
     is not found, so add the other path as well (and remove a duplicate).
    Origin: vendor
    Author: gregor herrmann <gregoa@debian.org>
    Last-Update: 2020-10-04
    

The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/libpdf-builder-perl/raw/master/debian/patches/font-path.patch

Thanks for considering,
  gregor herrmann,
  Debian Perl Group
