### PR TITLE
Fix reading colormap from TIFF

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -20,7 +20,7 @@ my $version = '3.019';          # PDFbuild.pl updates from 'version' file
 my @choice_list = ( # use array to guarantee order
 	# 'a' and 'n' are reserved, do not use as key [0]
 	# [1] is actual library name [2] is minimum version [3] description
-  ["t", "Graphics::TIFF", 6, "TIFF image support"],
+  ["t", "Graphics::TIFF", 7, "TIFF image support"],
         # improved TIFF image processing
   ["p", "Image::PNG::Libpng", 0.47, "PNG image support"],
         # advanced/fast PNG image processing

--- a/lib/PDF/Builder/Resource/XObject/Image/TIFF/File_GT.pm
+++ b/lib/PDF/Builder/Resource/XObject/Image/TIFF/File_GT.pm
@@ -7,7 +7,7 @@ use warnings;
 my $LAST_UPDATE = '3.010'; # manually update whenever code is changed
 
 use IO::File;
-use Graphics::TIFF ':all';  # already confirmed to be installed
+use Graphics::TIFF 7 ':all';  # already confirmed to be installed
 
 =head1 NAME
 
@@ -150,9 +150,7 @@ sub readTags {
     # TIFFTAG_CELLWIDTH dithering or halftoning matrix cell width
     # TIFFTAG_CELLLENGTH dithering or halftoning matrix cell height
     # palette RGB table definition
-    $self->{'colorMapOffset'} = $self->{'object'}->GetField(TIFFTAG_COLORMAP);
-    $self->{'colorMapSamples'} = $#{$self->{'colorMapOffset'}}+1;
-    $self->{'colorMapLength'} = $self->{'colorMapSamples'}*2; # shorts!
+    $self->{'colorMap'} = [ $self->{'object'}->GetField(TIFFTAG_COLORMAP) ];
     # TIFFTAG_GRAYRESPONSEUNIT describe integer->float mapping
     # TIFFTAG_GRAYRESPONSECURVE optical density of Gray curve at each point
 

--- a/t/tiff.t
+++ b/t/tiff.t
@@ -3,7 +3,7 @@ use warnings;
 use strict;
 use English qw' -no_match_vars ';
 use IPC::Cmd qw(can_run);
-use Test::More tests => 11;
+use Test::More tests => 12;
 
 use PDF::Builder;
 
@@ -181,6 +181,23 @@ my $expected = `convert $tiff -depth 1 -resize 1x1 txt:-`;
 # ----------
 
 is($example, $expected, 'lzw (converted to flate)');
+}
+
+SKIP: {
+    skip "Non-Linux system, or no 'convert'", 1 unless
+      $OSNAME eq 'linux'
+         and can_run('convert')
+         and can_run('tiffcp');
+system("convert rose: -type palette -depth 2 colormap.png && convert colormap.png $tiff && rm colormap.png");
+$pdf = PDF::Builder->new(-file => $pdfout);
+my $page = $pdf->page;
+$page->mediabox( $width, $height );
+$gfx = $page->gfx();
+my $img = $pdf->image_tiff($tiff);
+$gfx->image( $img, 0, 0, $width, $height );
+$pdf->save();
+$pdf->end();
+pass 'successfully read TIFF with colormap';
 }
 
 ##############################################################


### PR DESCRIPTION
Fixes issue #133. Requires Graphics::TIFF 7, which has just hit CPAN.