### PR TITLE
Correct number of colors for indexed colorspaces from TIFFs

### DIFF
--- a/lib/PDF/Builder/Resource/XObject/Image/TIFF.pm
+++ b/lib/PDF/Builder/Resource/XObject/Image/TIFF.pm
@@ -252,7 +252,7 @@ sub read_tiff {
     if ($tif->{'colorSpace'} eq 'Indexed') {
         my $dict = PDFDict();
         $pdf->new_obj($dict);
-        $self->colorspace(PDFArray(PDFName($tif->{'colorSpace'}), PDFName('DeviceRGB'), PDFNum(255), $dict));
+        $self->colorspace(PDFArray(PDFName($tif->{'colorSpace'}), PDFName('DeviceRGB'), PDFNum(2**$tif->{'bitsPerSample'}-1), $dict));
         $dict->{'Filter'} = PDFArray(PDFName('FlateDecode'));
         $tif->{'fh'}->seek($tif->{'colorMapOffset'}, 0);
         my $colormap;

--- a/lib/PDF/Builder/Resource/XObject/Image/TIFF_GT.pm
+++ b/lib/PDF/Builder/Resource/XObject/Image/TIFF_GT.pm
@@ -186,7 +186,7 @@ sub read_tiff {
     if ($tif->{'colorSpace'} eq 'Indexed') {
         my $dict = PDFDict();
         $pdf->new_obj($dict);
-        $self->colorspace(PDFArray(PDFName($tif->{'colorSpace'}), PDFName('DeviceRGB'), PDFNum(255), $dict));
+        $self->colorspace(PDFArray(PDFName($tif->{'colorSpace'}), PDFName('DeviceRGB'), PDFNum(2**$tif->{'bitsPerSample'}-1), $dict));
         $dict->{'Filter'} = PDFArray(PDFName('FlateDecode'));
         my ($red, $green, $blue) = @{$tif->{'colorMap'}};
         $dict->{' stream'} = '';


### PR DESCRIPTION
This fixes the rest of #133 for me. Does your PDF viewer still complain about the output?