### PR TITLE
Specify full path for imagemagick convert if using Windows

### DIFF
--- a/t/tiff.t
+++ b/t/tiff.t
@@ -160,7 +160,7 @@ is($example, $expected, 'G4 (not converted to flate)');
 SKIP: {
     skip "no 'convert'", 1 unless can_run($convert);
 # ----------
-system(sprintf"$convert -depth 1 -gravity center -pointsize 78 -size %dx%d caption:'Lorem ipsum etc etc' -background white -alpha off -compress LZW %s", $width, $height, $tiff);
+system(sprintf"$convert -depth 1 -gravity center -pointsize 78 -size %dx%d caption:'Lorem ipsum etc etc' -background white -alpha off -compress lzw %s", $width, $height, $tiff);
 # ----------
 $pdf = PDF::Builder->new(-file => $pdfout);
 my $page = $pdf->page;
@@ -188,7 +188,8 @@ SKIP: {
       $has_GT and $OSNAME eq 'linux'
          and can_run('convert');
 # .png file is temporary file (output, input, erased)
-system("convert rose: -type palette -depth 2 colormap.png && convert colormap.png $tiff && rm colormap.png");
+system("$convert rose: -type palette -depth 2 colormap.png");
+system("$convert colormap.png $tiff");
 $pdf = PDF::Builder->new(-file => $pdfout);
 my $page = $pdf->page;
 $page->mediabox( $width, $height );
@@ -203,7 +204,7 @@ pass 'successfully read TIFF with colormap';
 ##############################################################
 # cleanup. all tests involving these files skipped?
 
-unlink $pdfout, $tiff;
+unlink $pdfout, $tiff, 'colormap.png';
 
 ##############################################################
 

--- a/t/tiff.t
+++ b/t/tiff.t
@@ -129,7 +129,7 @@ is($example, $expected, 'alpha');
 # Graphics::TIFF needed or you get message "Chunked CCITT G4 TIFF not supported"
 #  from PDF::Builder's TIFF processing library.
 
-my $convert = 'magick convert';
+my $convert = 'magick';
 if (not can_run($convert)) {
     if ($OSNAME eq 'linux') {
         $convert = 'convert'
@@ -142,6 +142,7 @@ SKIP: {
     skip "Non-Linux system, or no 'convert' or no 'tiffcp'", 1 unless
       $has_GT and can_run($convert) and can_run('tiffcp');
 # ----------
+if ($convert !~ /convert/) { $convert .= ' convert' }
 system(sprintf "$convert -depth 1 -gravity center -pointsize 78 -size %dx%d caption:'Lorem ipsum etc etc' -background white -alpha off %s", $width, $height, $tiff);
 system("tiffcp -c g3 $tiff tmp.tif && mv tmp.tif $tiff");
 # ----------

--- a/t/tiff.t
+++ b/t/tiff.t
@@ -129,15 +129,18 @@ is($example, $expected, 'alpha');
 # Graphics::TIFF needed or you get message "Chunked CCITT G4 TIFF not supported"
 #  from PDF::Builder's TIFF processing library.
 
-my $convert = 'convert';
-if ($OSNAME eq 'MSWin32') {
-    $convert = File::Spec->catfile($ENV{PROGRAMFILES}, 'convert');
+my $convert = 'magick convert';
+if (not can_run($convert)) {
+    if ($OSNAME eq 'linux') {
+        $convert = 'convert'
+    }
+    elsif ($OSNAME eq 'MSWin32') {
+        $convert = File::Spec->catfile($ENV{PROGRAMFILES}, 'ImageMagick', 'convert');
+    }
 }
-
 SKIP: {
     skip "Non-Linux system, or no 'convert' or no 'tiffcp'", 1 unless
-      $has_GT and can_run($convert)
-         and can_run('tiffcp');
+      $has_GT and can_run($convert) and can_run('tiffcp');
 # ----------
 system(sprintf "$convert -depth 1 -gravity center -pointsize 78 -size %dx%d caption:'Lorem ipsum etc etc' -background white -alpha off %s", $width, $height, $tiff);
 system("tiffcp -c g3 $tiff tmp.tif && mv tmp.tif $tiff");

--- a/t/tiff.t
+++ b/t/tiff.t
@@ -160,7 +160,7 @@ is($example, $expected, 'G4 (not converted to flate)');
 SKIP: {
     skip "no 'convert'", 1 unless can_run($convert);
 # ----------
-system(sprintf"$convert -depth 1 -gravity center -pointsize 78 -size %dx%d caption:'Lorem ipsum etc etc' -background white -alpha off %s -compress LZW", $width, $height, $tiff);
+system(sprintf"$convert -depth 1 -gravity center -pointsize 78 -size %dx%d caption:'Lorem ipsum etc etc' -background white -alpha off -compress LZW %s", $width, $height, $tiff);
 # ----------
 $pdf = PDF::Builder->new(-file => $pdfout);
 my $page = $pdf->page;

--- a/t/tiff.t
+++ b/t/tiff.t
@@ -118,8 +118,8 @@ $pdf->save();
 $pdf->end();
 
 # ----------
-my $example = `convert $pdfout -depth 1 -resize 1x1 txt:-`;
-my $expected = `convert $tiff -depth 1 -resize 1x1 txt:-`;
+my $example = `$convert $pdfout -depth 1 -resize 1x1 txt:-`;
+my $expected = `$convert $tiff -depth 1 -resize 1x1 txt:-`;
 # ----------
 
 is($example, $expected, 'alpha');
@@ -186,7 +186,7 @@ is($example, $expected, 'lzw (converted to flate)');
 SKIP: {
     skip "Non-Linux system, or no 'convert'", 1 unless
       $has_GT and $OSNAME eq 'linux'
-         and can_run('convert');
+         and can_run($convert);
 # .png file is temporary file (output, input, erased)
 system("$convert rose: -type palette -depth 2 colormap.png");
 system("$convert colormap.png $tiff");

--- a/t/tiff.t
+++ b/t/tiff.t
@@ -76,22 +76,14 @@ ok($@, q{Fail fast if the requested file doesn't exist});
 
 ##############################################################
 # common data for remaining tests
-my $width = 568;
-my $height = 1000;
+my $width = 1000;
+my $height = 100;
 $tiff = 'test.tif';
 my $pdfout = 'test.pdf';
 
-# WARNING: do not attempt to run the following 3 tests on a
-# Windows system. Windows has a 'convert' utility to convert
-# a filesystem from FAT32 to NTFS, and you don't want to
-# accidentally run that one! The test ($OSNAME) is for 'linux'
-# but testing for 'not windows' might do just as well. Even
-# better might be to see if 'convert' and 'tiffcp' are the
-# right utilties, if found. Otherwise, the OS is irrelevant.
-#
-# NOTE: following 3 tests use Linux/TIFF utilities convert
-# and tiffcp. They may require software installation on 
-# your Linux system, and will be skipped if the necessary
+# NOTE: following 3 tests use the utilities imagemagick
+# They may require software installation on
+# your system, and will be skipped if the necessary
 # software is not found.
 
 ##############################################################
@@ -125,7 +117,7 @@ is($example, $expected, 'alpha');
 }
 
 ##############################################################
-# tiffcp, convert and Graphics::TIFF not available on all systems.
+# convert and Graphics::TIFF not available on all systems.
 # Graphics::TIFF needed or you get message "Chunked CCITT G4 TIFF not supported"
 #  from PDF::Builder's TIFF processing library.
 
@@ -139,12 +131,10 @@ if (not can_run($convert)) {
     }
 }
 SKIP: {
-    skip "Non-Linux system, or no 'convert' or no 'tiffcp'", 1 unless
-      $has_GT and can_run($convert) and can_run('tiffcp');
+    skip "no 'convert'", 1 unless $has_GT and can_run($convert);
 # ----------
 if ($convert !~ /convert/) { $convert .= ' convert' }
-system(sprintf "$convert -depth 1 -gravity center -pointsize 78 -size %dx%d caption:'Lorem ipsum etc etc' -background white -alpha off %s", $width, $height, $tiff);
-system("tiffcp -c g3 $tiff tmp.tif && mv tmp.tif $tiff");
+system(sprintf "$convert -depth 1 -gravity center -pointsize 78 -size %dx%d caption:'Lorem ipsum etc etc' -background white -alpha off -compress Group4 %s", $width, $height, $tiff);
 # ----------
 $pdf = PDF::Builder->new(-file => $pdfout);
 my $page = $pdf->page();
@@ -160,20 +150,17 @@ my $example = `$convert $pdfout -depth 1 -colorspace gray -alpha off -resize 1x1
 my $expected = `$convert $tiff -depth 1 -resize 1x1 txt:-`;
 # ----------
 
-is($example, $expected, 'G3 (not converted to flate)');
+is($example, $expected, 'G4 (not converted to flate)');
 }
 
 ##############################################################
-# tiffcp and convert not available on all systems.
+# convert not available on all systems.
 # Graphics::TIFF not needed for this test
 
 SKIP: {
-    skip "Non-Linux system, or no 'convert' or no 'tiffcp'", 1 unless
-         can_run($convert)
-         and can_run('tiffcp');
+    skip "no 'convert'", 1 unless can_run($convert);
 # ----------
-system(sprintf"$convert -depth 1 -gravity center -pointsize 78 -size %dx%d caption:'Lorem ipsum etc etc' -background white -alpha off %s", $width, $height, $tiff);
-system("tiffcp -c lzw $tiff tmp.tif && mv tmp.tif $tiff");
+system(sprintf"$convert -depth 1 -gravity center -pointsize 78 -size %dx%d caption:'Lorem ipsum etc etc' -background white -alpha off %s -compress LZW", $width, $height, $tiff);
 # ----------
 $pdf = PDF::Builder->new(-file => $pdfout);
 my $page = $pdf->page;


### PR DESCRIPTION
I can't test this, as I don't have a windows machine, but if we can specify the full path of the convert executable, we should be able use if with windows.