### PR TITLE
+ LZW compression and use for TIFF images that are LZW-compressed

### DIFF
--- a/lib/PDF/Builder/Basic/PDF/Filter/LZWDecode.pm
+++ b/lib/PDF/Builder/Basic/PDF/Filter/LZWDecode.pm
@@ -4,10 +4,12 @@ use base 'PDF::Builder::Basic::PDF::Filter::FlateDecode';
 
 use strict;
 use warnings;
+use Carp;
+
 #no warnings qw[ deprecated recursion uninitialized ];
 
 # VERSION
-my $LAST_UPDATE = '3.021'; # manually update whenever code is changed
+my $LAST_UPDATE = '3.021';    # manually update whenever code is changed
 
 =head1 NAME
 
@@ -16,90 +18,198 @@ PDF::Builder::Basic::PDF::Filter::LZWDecode - compress and uncompress stream fil
 =cut
 
 sub new {
-    my ($class, $decode_parms) = @_;
+    my ( $class, $decode_parms ) = @_;
 
-    my $self = {
-        DecodeParms => $decode_parms,
-    };
-
-    $self->{'table'} = [map { pack('C', $_) } (0 .. 255, 0, 0)];
-    $self->{'initial_code_length'} = 9;
-    $self->{'code_length'} = 9;
-    $self->{'clear_table'} = 256;
-    $self->{'eod_marker'} = 257;
-    $self->{'next_code'} = 258;
+    my $self = { DecodeParms => $decode_parms, };
 
     bless $self, $class;
+    $self->_reset_code;
     return $self;
 }
 
 sub infilt {
-    my ($self, $data, $is_last) = @_;
+    my ( $self, $data, $is_last ) = @_;
 
-    my ($code, $result);
-    my $partial_code = $self->{'partial_code'};
-    my $partial_bits = $self->{'partial_bits'};
+    my ( $code, $result );
+    my $partial_code = $self->{partial_code};
+    my $partial_bits = $self->{partial_bits};
 
     my $early_change = 1;
-    if ($self->{'DecodeParms'} and $self->{'DecodeParms'}->{'EarlyChange'}) {
-        $early_change = $self->{'DecodeParms'}->{'EarlyChange'}->val();
+    if ( $self->{DecodeParms} and $self->{DecodeParms}->{EarlyChange} ) {
+        $early_change = $self->{DecodeParms}->{EarlyChange}->val();
     }
+    $self->{table} = [ map { chr } 0 .. $self->{clear_table} - 1 ];
 
-    while ($data ne '') {
-        ($code, $partial_code, $partial_bits) = $self->read_dat(\$data, $partial_code, $partial_bits, $self->{'code_length'});
-        last unless defined $code;
+    while ( $data ne q{} ) {
+        ( $code, $partial_code, $partial_bits ) =
+          $self->read_dat( \$data, $partial_code, $partial_bits,
+            $self->{code_length} );
+        if ( not defined $code ) { last }
 
-        unless ($early_change) {
-            if ($self->{'next_code'} == (1 << $self->{'code_length'}) and $self->{'code_length'} < 12) {
-                $self->{'code_length'}++;
+        if ( not $early_change ) {
+            if (    $self->{next_code} == ( 1 << $self->{code_length} )
+                and $self->{code_length} < 12 )
+            {
+                $self->{code_length}++;
             }
         }
 
-        if      ($code == $self->{'clear_table'}) {
-            $self->{'code_length'} = $self->{'initial_code_length'};
-            $self->{'next_code'} = $self->{'eod_marker'} + 1;
+        if ( $code == $self->{clear_table} ) {
+            $self->{code_length} = $self->{initial_code_length};
+            $self->{next_code}   = $self->{eod_marker} + 1;
             next;
-        } elsif ($code == $self->{'eod_marker'}) {
+        }
+        elsif ( $code == $self->{eod_marker} ) {
             last;
-        } elsif ($code > $self->{'eod_marker'}) {
-            $self->{'table'}[$self->{'next_code'}] = $self->{'table'}[$code];
-            $self->{'table'}[$self->{'next_code'}] .= substr($self->{'table'}[$code + 1], 0, 1);
-            $result .= $self->{'table'}[$self->{'next_code'}];
-            $self->{'next_code'}++;
-        } else {
-            $self->{'table'}[$self->{'next_code'}] = $self->{'table'}[$code];
-            $result .= $self->{'table'}[$self->{'next_code'}];
-            $self->{'next_code'}++;
+        }
+        elsif ( $code > $self->{eod_marker} ) {
+            $self->{table}[ $self->{next_code} ] = $self->{table}[$code];
+            $self->{table}[ $self->{next_code} ] .=
+              substr $self->{table}[ $code + 1 ], 0, 1;
+            $result .= $self->{table}[ $self->{next_code} ];
+            $self->{next_code}++;
+        }
+        else {
+            $self->{table}[ $self->{next_code} ] = $self->{table}[$code];
+            $result .= $self->{table}[ $self->{next_code} ];
+            $self->{next_code}++;
         }
 
         if ($early_change) {
-            if ($self->{'next_code'} == (1 << $self->{'code_length'}) and $self->{'code_length'} < 12) {
-                $self->{'code_length'}++;
+            if (    $self->{next_code} == ( 1 << $self->{code_length} )
+                and $self->{code_length} < 12 )
+            {
+                $self->{code_length}++;
             }
         }
     }
-    $self->{'partial_code'} = $partial_code;
-    $self->{'partial_bits'} = $partial_bits;
+    $self->{partial_code} = $partial_code;
+    $self->{partial_bits} = $partial_bits;
     return $result;
 }
 
+sub outfilt {
+    my ( $self, $str, $is_end ) = @_;
+    my $max_code   = 32767;
+    my $bytes_in   = 0;
+    my $checkpoint = 0;
+    my $last_ratio = 0;
+    my $seen       = q{};
+    $self->{buf}     = q{};
+    $self->{buf_pos} = 0;
+    $self->_write_code( $self->{clear_table} );
+
+    for my $i ( 0 .. length $str ) {
+        my $char = substr $str, $i, 1;
+        $bytes_in += 1;
+
+        if ( exists $self->{table}{ $seen . $char } ) {
+            $seen .= $char;
+            next;
+        }
+
+        $self->_write_code( $self->{table}{$seen} );
+
+        $self->_new_code( $seen . $char );
+
+        $seen = $char;
+
+        if ( $self->{at_max_code} ) {
+            $self->_write_code( $self->{clear_table} );
+            $self->_reset_code;
+
+            undef $checkpoint;
+            undef $last_ratio;
+        }
+    }
+    $self->_write_code( $self->{table}{$seen} );    #last bit of input
+    $self->_write_code( $self->{eod_marker} );
+    my $padding = length( $self->{buf} ) % 8;
+    if ( $padding > 0 ) {
+        $padding = 8 - $padding;
+        $self->{buf} .= '0' x $padding;
+    }
+    return pack 'B*', $self->{buf};
+}
+
+sub _reset_code {
+    my $self = shift;
+
+    $self->{initial_code_length} = 9;
+    $self->{max_code_length}     = 12;
+    $self->{code_length}         = $self->{initial_code_length};
+    $self->{clear_table}         = 256;
+    $self->{eod_marker}          = $self->{clear_table} + 1;
+    $self->{next_code}           = $self->{eod_marker} + 1;
+    $self->{next_increase}       = 2**$self->{code_length};
+    $self->{at_max_code}         = 0;
+    $self->{table} = { map { chr $_ => $_ } 0 .. $self->{clear_table} - 1 };
+    return;
+}
+
+sub _new_code {
+    my ( $self, $word ) = @_;
+
+    if ( $self->{at_max_code} == 0 ) {
+        $self->{table}{$word} = $self->{next_code};
+        $self->{next_code} += 1;
+    }
+
+    if ( $self->{next_code} >= $self->{next_increase} ) {
+        if ( $self->{code_length} < $self->{max_code_length} ) {
+            $self->{code_length}   += 1;
+            $self->{next_increase} *= 2;
+        }
+        else {
+            $self->{at_max_code} = 1;
+        }
+    }
+    return;
+}
+
+sub _write_code {
+    my ( $self, $code ) = @_;
+
+    if ( not defined $code ) { return }
+
+    if ( $code > ( 2**$self->{code_length} ) ) {
+        croak
+          "Code $code too large for current code length $self->{code_length}";
+    }
+
+    for my $bit ( reverse 0 .. ( $self->{code_length} - 1 ) ) {
+        if ( ( $code >> $bit ) & 1 ) {
+            $self->{buf} .= '1';
+        }
+        else {
+            $self->{buf} .= '0';
+        }
+    }
+
+    $self->{buf_pos} += $self->{code_length};
+    return;
+}
+
 sub read_dat {
-    my ($self, $data_ref, $partial_code, $partial_bits, $code_length) = @_;
+    my ( $self, $data_ref, $partial_code, $partial_bits, $code_length ) = @_;
 
-    $partial_bits = 0 unless defined $partial_bits;
+    if ( not defined $partial_bits ) { $partial_bits = 0 }
+    if ( not defined $partial_code ) { $partial_code = 0 }
 
-    while ($partial_bits < $code_length) {
-        return (undef, $partial_code, $partial_bits) unless length($$data_ref);
-        $partial_code = ($partial_code << 8) + unpack('C', $$data_ref);
-        substr($$data_ref, 0, 1) = '';
+    while ( $partial_bits < $code_length ) {
+        if ( not length ${$data_ref} ) {
+            return ( undef, $partial_code, $partial_bits );
+        }
+        $partial_code = ( $partial_code << 8 ) + unpack 'C', ${$data_ref};
+        substr( ${$data_ref}, 0, 1 ) = q{};
         $partial_bits += 8;
     }
 
-    my $code = $partial_code >> ($partial_bits - $code_length);
-    $partial_code &= (1 << ($partial_bits - $code_length)) - 1;
+    my $code = $partial_code >> ( $partial_bits - $code_length );
+    $partial_code &= ( 1 << ( $partial_bits - $code_length ) ) - 1;
     $partial_bits -= $code_length;
 
-    return ($code, $partial_code, $partial_bits);
+    return ( $code, $partial_code, $partial_bits );
 }
 
 1;

--- a/lib/PDF/Builder/Resource/XObject/Image/TIFF.pm
+++ b/lib/PDF/Builder/Resource/XObject/Image/TIFF.pm
@@ -158,11 +158,16 @@ sub handle_lzw {
         $self->{' stream'} = '';
         my $d = scalar @{$tif->{'imageOffset'}};
         foreach (1 .. $d) {
-            my $buf;
             $tif->{'fh'}->seek(shift(@{$tif->{'imageOffset'}}), 0);
-            $tif->{'fh'}->read($self->{' stream'}, shift(@{$tif->{'imageLength'}}));
+            my $buf;
+            $tif->{'fh'}->read($buf, shift(@{$tif->{'imageLength'}}));
+            my $filter = PDF::Builder::Basic::PDF::Filter::LZWDecode->new();
+            $self->{' stream'} .= $filter->infilt($buf);
         }
-    } else {
+        my $filter = PDF::Builder::Basic::PDF::Filter::LZWDecode->new();
+        $self->{' stream'} = $filter->outfilt($self->{' stream'});
+    }
+    else {
         $tif->{'fh'}->seek($tif->{'imageOffset'}, 0);
         $tif->{'fh'}->read($self->{' stream'}, $tif->{'imageLength'});
     }

--- a/lib/PDF/Builder/Resource/XObject/Image/TIFF_GT.pm
+++ b/lib/PDF/Builder/Resource/XObject/Image/TIFF_GT.pm
@@ -643,6 +643,7 @@ sub handle_ccitt {
     return $self;
 } # end of handle_ccitt()
 
+
 sub handle_lzw {
     my ($self, $pdf, $tif, %opts) = @_;
 
@@ -656,9 +657,18 @@ sub handle_lzw {
     $decode->{'EndOfLine'} = PDFBool(1);
     $decode->{'EncodedByteAlign'} = PDFBool(1);
 
-    for my $i (0 .. $tif->{'object'}->NumberOfStrips() - 1) {
-        $self->{' stream'} .= $tif->{'object'}->ReadRawStrip($i, -1);
+    my $n_strips = $tif->{'object'}->NumberOfStrips();
+    if ($n_strips == 1) {
+        $self->{' stream'} .= $tif->{'object'}->ReadRawStrip(0, -1);
+        return $self;
     }
+
+    my $stream = '';
+    for my $i (0 .. $n_strips - 1) {
+        $stream .= $tif->{'object'}->ReadEncodedStrip($i, -1);
+    }
+    my $filter = PDF::Builder::Basic::PDF::Filter::LZWDecode->new();
+    $self->{' stream'} .= $filter->outfilt($stream);
 
     return $self;
 } # end of handle_lzw()

--- a/t/filter-lzwdecode.t
+++ b/t/filter-lzwdecode.t
@@ -1,0 +1,51 @@
+#!/usr/bin/perl
+use warnings;
+use strict;
+
+use Test::More tests => 6;
+
+use PDF::Builder::Basic::PDF::Filter::LZWDecode;
+
+my $filter = PDF::Builder::Basic::PDF::Filter::LZWDecode->new();
+
+my $in = 'BT /F1 24 Tf 100 700 Td (Hello World)Tj ET';
+my $out = $filter->outfilt($in);
+
+is $filter->infilt($out), $in, 'LZWDecode test string round-tripped correctly';
+
+my $repeat = 22;
+note( 'Test data size: ' . length($in)*$repeat );
+
+$filter = PDF::Builder::Basic::PDF::Filter::LZWDecode->new();
+$out = $filter->outfilt($in x $repeat);
+
+note( 'Final bits: '.$filter->{code_length} );
+
+cmp_ok length($out), '<', length($in)*$repeat, "Data compresses smaller";
+
+$filter = PDF::Builder::Basic::PDF::Filter::LZWDecode->new();
+is $filter->infilt($out), $in x $repeat, 'Data decompresses unchanged at 10bit boundary';
+
+$in = pack "H*", '8000000014040807050001e100f840fd00e0003fd00ff8a44e2b01';
+my $expected = pack "H*", '00000180000003800000078000000f8000003f80e000ff80ffffff80ffffff80';
+$filter = PDF::Builder::Basic::PDF::Filter::LZWDecode->new();
+$out = $filter->infilt($in);
+is $out, $expected, 'decompress binary data';
+
+($in, $expected) = ($expected, $in);
+$filter = PDF::Builder::Basic::PDF::Filter::LZWDecode->new();
+$out = $filter->outfilt($in);
+is $out, $expected, 'compress binary data';
+
+$repeat = 30000;
+$in = '';
+for (0..$repeat) {$in .= chr(int(rand(256)))}
+note( 'Test data size: ' . length($in) );
+
+$filter = PDF::Builder::Basic::PDF::Filter::LZWDecode->new();
+$out = $filter->outfilt($in);
+
+note( 'Final bits: '.$filter->{code_length} );
+
+$filter = PDF::Builder::Basic::PDF::Filter::LZWDecode->new();
+is $filter->infilt($out), $in, 'Data decompresses unchanged after reaching max code length';

--- a/t/tiff.t
+++ b/t/tiff.t
@@ -4,7 +4,7 @@ use strict;
 use English qw( -no_match_vars );
 use IPC::Cmd qw(can_run run);
 use File::Spec;
-use Test::More tests => 13;
+use Test::More tests => 15;
 
 use PDF::Builder;
 # 0: allow use of Graphics::TIFF, 1: force non-GT usage
@@ -170,7 +170,7 @@ is($example, $expected, 'G4 (not converted to flate)');
 # convert and Graphics::TIFF needed for these two tests
 
 SKIP: {
-    skip "No 'convert' utility available, or no Graphics::TIFF.", 1 unless
+    skip "No 'convert' utility available, or no Graphics::TIFF.", 2 unless
         defined $convert and defined $gs and $has_GT;
 
 system("$convert -depth 1 -gravity center -pointsize 78 -size ${width}x${height} caption:\"A caption for the image\" -background white -alpha off -compress lzw $tiff_f");
@@ -190,11 +190,30 @@ my $example = `$convert out.png -depth 1 -alpha off txt:-`;
 my $expected = `$convert $tiff_f -depth 1 -alpha off txt:-`;
 # ----------
 
-is($example, $expected, 'lzw (not converted to flate) with GT');
+is($example, $expected, 'single-strip lzw (not converted to flate) with GT');
+
+system("$convert -depth 1 -gravity center -pointsize 78 -size ${width}x${height} caption:\"A caption for the image\" -background white -alpha off -define tiff:rows-per-strip=50 -compress lzw $tiff_f");
+# ----------
+$pdf = PDF::Builder->new(-file => $pdfout);
+$page = $pdf->page();
+$page->mediabox( $width, $height );
+$gfx = $page->gfx();
+$img = $pdf->image_tiff($tiff_f, -nouseGT => 0);
+$gfx->image( $img, 0, 0, $width, $height );
+$pdf->save();
+$pdf->end();
+
+# ----------
+system("$gs -q -dNOPAUSE -dBATCH -sDEVICE=pnggray -g${width}x${height} -dPDFFitPage -dUseCropBox -sOutputFile=out.png $pdfout");
+$example = `$convert out.png -depth 1 -alpha off txt:-`;
+$expected = `$convert $tiff_f -depth 1 -alpha off txt:-`;
+# ----------
+
+is($example, $expected, 'multi-strip lzw (not converted to flate) with GT');
 }
 
 SKIP: {
-    skip "No 'convert' utility available.", 1 unless
+    skip "No 'convert' utility available.", 2 unless
         defined $convert and defined $gs;
 
 system("$convert -depth 1 -gravity center -pointsize 78 -size ${width}x${height} caption:\"A caption for the image\" -background white -alpha off -compress lzw $tiff_f");
@@ -214,7 +233,27 @@ my $example = `$convert out.png -depth 1 -alpha off txt:-`;
 my $expected = `$convert $tiff_f -depth 1 -alpha off txt:-`;
 # ----------
 
-is($example, $expected, 'lzw (not converted to flate) without GT');
+is($example, $expected, 'single-strip lzw (not converted to flate) without GT');
+
+skip "currently fails due to bug inherited from PDF::API2", 1;
+system("$convert -depth 1 -gravity center -pointsize 78 -size ${width}x${height} caption:\"A caption for the image\" -background white -alpha off -define tiff:rows-per-strip=50 -compress lzw $tiff_f");
+# ----------
+$pdf = PDF::Builder->new(-file => $pdfout);
+$page = $pdf->page();
+$page->mediabox( $width, $height );
+$gfx = $page->gfx();
+$img = $pdf->image_tiff($tiff_f, -nouseGT => 1);
+$gfx->image( $img, 0, 0, $width, $height );
+$pdf->save();
+$pdf->end();
+
+# ----------
+system("$gs -q -dNOPAUSE -dBATCH -sDEVICE=pnggray -g${width}x${height} -dPDFFitPage -dUseCropBox -sOutputFile=out.png $pdfout");
+$example = `$convert out.png -depth 1 -alpha off txt:-`;
+$expected = `$convert $tiff_f -depth 1 -alpha off txt:-`;
+# ----------
+
+is($example, $expected, 'multi-strip lzw (not converted to flate) without GT');
 }
 
 # read TIFF with colormap ------------------


### PR DESCRIPTION
This is where I am at the moment. The LZW compression/decompression code round-trips for everything I have seen so far. However, it is SLOW.

Some of your collection of TIFFs still do not display properly. I currently suspect this is not due to the LZW compression, but rather because of missing image parameters in the PDF. Can you help me fix this?

Once we have the display bugs fixed, I'll look at addressing the performance problems.