### PR TITLE
Ci

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,14 +3,32 @@ on:
   - push
   - pull_request
 jobs:
-  test:
-    name: Test
+  full-ubuntu:
+    name: Full_Ubuntu
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - run: sudo apt install fonts-dejavu-core libfont-ttf-perl libgd-perl libio-compress-perl libtest-exception-perl libtest-memory-cycle-perl
+      - run: sudo apt-add-repository ppa:jeffreyratcliffe/ppa
+      - run: sudo apt update
+      - run: sudo apt install libfont-ttf-perl libgd-perl libio-compress-perl libtest-exception-perl libtest-memory-cycle-perl ghostscript libgraphics-tiff-perl
       - run: perl Makefile.PL
-      - run: make test
+      - run: make test TEST_VERBOSE=1
+  nogt:
+    name: noGT
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: sudo apt install libfont-ttf-perl libgd-perl libio-compress-perl libtest-exception-perl libtest-memory-cycle-perl ghostscript
+      - run: perl Makefile.PL
+      - run: make test TEST_VERBOSE=1
+  nogt_nogs:
+    name: noGT_noGS
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: sudo apt install libfont-ttf-perl libgd-perl libio-compress-perl libtest-exception-perl libtest-memory-cycle-perl
+      - run: perl Makefile.PL
+      - run: make test TEST_VERBOSE=1
 # lint:
 #   name: Lint
 #   runs-on: ubuntu-latest

--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -1,6 +1,7 @@
 #!/usr/bin/perl
 use warnings;
 use strict;
+use File::Spec;
 
 use Test::More tests => 7;
 
@@ -44,7 +45,7 @@ is($pdf->pages(),
 
 # Open a PDF
 
-$pdf = PDF::Builder->open('t/resources/sample.pdf');
+$pdf = PDF::Builder->open(File::Spec->catfile('t', 'resources', 'sample.pdf'));
 
 isa_ok($pdf,
        'PDF::Builder',

--- a/t/tiff.t
+++ b/t/tiff.t
@@ -116,7 +116,7 @@ if      (can_run("magick")) {
 # check if reasonably recent version
 $convert = check_version($convert, '-version', 'ImageMagick ([0-9.]+)', '6.9.7');
 # $convert undef if not installed, can't parse format, version too low
-# will skip "No 'convert' utility"
+# will skip "No ImageMagick"
 
 # on Windows, ImageMagick can be 64-bit or 32-bit version, so try both. it's
 #   needed for some magick convert operations, and also standalone, and
@@ -132,17 +132,17 @@ if      (can_run("gswin64c")) {
 # check if reasonably recent version
 $gs = check_version($gs, '-v', 'Ghostscript ([0-9.]+)', '9.25.0');
 # $convert undef if not installed, can't parse format, version too low
-# will skip "No 'convert' utility"
+# will skip "No Ghostscript"
 
 # alpha layer handling ------------------
 # convert and Graphics::TIFF needed
 
 # 9
 SKIP: {
-    skip "No 'convert' utility available, or no Graphics::TIFF.", 1 unless
+    skip "Either ImageMagick, Ghostscript or Graphics::TIFF not available.", 1 unless
         defined $convert and defined $gs and $has_GT;
 
-system("$convert -depth 1 -gravity center -pointsize 78 -size ${width}x${height} caption:\"A caption for the image\" $tiff_f");
+system("$convert -depth 1 -font DejaVu-Sans -gravity center -pointsize 78 -size ${width}x${height} caption:\"A caption for the image\" $tiff_f");
 # ----------
 $pdf = PDF::Builder->new(-file => $pdfout);
 $page = $pdf->page();
@@ -155,8 +155,8 @@ $pdf->end();
 
 # ----------
 system("$gs -q -dNOPAUSE -dBATCH -sDEVICE=pngalpha -g${width}x${height} -dPDFFitPage -dUseCropBox -sOutputFile=$pngout $pdfout");
-$example = `$convert $pngout -colorspace gray -depth 1 txt:-`;
-$expected = `$convert $tiff_f -depth 1 txt:-`;
+my $example = `$convert $pngout -colorspace gray -depth 1 txt:-`;
+my $expected = `$convert $tiff_f -depth 1 txt:-`;
 # ----------
 
 is($example, $expected, 'alpha + flate');
@@ -167,10 +167,10 @@ is($example, $expected, 'alpha + flate');
 
 # 10
 SKIP: {
-    skip "No 'convert' utility available, or no Graphics::TIFF.", 1 unless
+    skip "Either ImageMagick, Ghostscript or Graphics::TIFF not available.", 1 unless
         defined $convert and defined $gs and $has_GT;
 
-system("$convert -depth 1 -gravity center -pointsize 78 -size ${width}x${height} caption:\"A caption for the image\" -background white -alpha off -compress Group4 $tiff_f");
+system("$convert -depth 1 -font DejaVu-Sans -gravity center -pointsize 78 -size ${width}x${height} caption:\"A caption for the image\" -background white -alpha off -compress Group4 $tiff_f");
 # ----------
 $pdf = PDF::Builder->new(-file => $pdfout);
 $page = $pdf->page();
@@ -195,10 +195,10 @@ is($example, $expected, 'G4 (not converted to flate)');
 
 # 11
 SKIP: {
-    skip "No 'convert' utility available, or no Graphics::TIFF.", 1 unless
+    skip "Either ImageMagick, Ghostscript or Graphics::TIFF not available.", 1 unless
         defined $convert and defined $gs and $has_GT;
 
-system("$convert -depth 1 -gravity center -pointsize 78 -size ${width}x${height} caption:\"A caption for the image\" -background white -alpha off -compress lzw $tiff_f");
+system("$convert -depth 1 -font DejaVu-Sans -gravity center -pointsize 78 -size ${width}x${height} caption:\"A caption for the image\" -background white -alpha off -compress lzw $tiff_f");
 # ----------
 $pdf = PDF::Builder->new(-file => $pdfout);
 $page = $pdf->page();
@@ -223,7 +223,7 @@ SKIP: {
     skip "No 'convert' utility available, or no Graphics::TIFF.", 1 unless
         defined $convert and defined $gs and $has_GT;
 
-system("$convert -depth 1 -gravity center -pointsize 78 -size ${width}x${height} caption:\"A caption for the image\" -background white -alpha off -define tiff:rows-per-strip=50 -compress lzw $tiff_f");
+system("$convert -depth 1 -font DejaVu-Sans -gravity center -pointsize 78 -size ${width}x${height} caption:\"A caption for the image\" -background white -alpha off -define tiff:rows-per-strip=50 -compress lzw $tiff_f");
 # ----------
 $pdf = PDF::Builder->new(-file => $pdfout);
 $page = $pdf->page();
@@ -278,7 +278,7 @@ SKIP: {
 $width = 1000;
 $height = 100;
 
-system("$convert -depth 1 -gravity center -pointsize 78 -size ${width}x${height} caption:\"A caption for the image\" -compress lzw $tiff_f");
+system("$convert -depth 1 -font DejaVu-Sans -gravity center -pointsize 78 -size ${width}x${height} caption:\"A caption for the image\" -compress lzw $tiff_f");
 # ----------
 $pdf = PDF::Builder->new(-file => $pdfout);
 $page = $pdf->page();
@@ -300,10 +300,10 @@ is($example, $expected, 'alpha + lzw');
 
 # 15
 SKIP: {
-    skip "No 'convert' utility available.", 1 unless
+    skip "Either ImageMagick or Ghostscript not available.", 1 unless
         defined $convert and defined $gs;
 
-system("$convert -depth 1 -gravity center -pointsize 78 -size ${width}x${height} caption:\"A caption for the image\" -background white -alpha off -compress lzw $tiff_f");
+system("$convert -depth 1 -font DejaVu-Sans -gravity center -pointsize 78 -size ${width}x${height} caption:\"A caption for the image\" -background white -alpha off -compress lzw $tiff_f");
 # ----------
 $pdf = PDF::Builder->new(-file => $pdfout);
 $page = $pdf->page();
@@ -356,7 +356,7 @@ $height = 100;
 SKIP: {
    #skip "currently fails due to bug inherited from PDF::API2", 1;
     skip "multi-strip lzw without GT is not currently supported", 1;
-system("$convert -depth 1 -gravity center -pointsize 78 -size ${width}x${height} caption:\"A caption for the image\" -background white -alpha off -define tiff:rows-per-strip=50 -compress lzw $tiff_f");
+system("$convert -depth 1 -font DejaVu-Sans -gravity center -pointsize 78 -size ${width}x${height} caption:\"A caption for the image\" -background white -alpha off -define tiff:rows-per-strip=50 -compress lzw $tiff_f");
 # ----------
 $pdf = PDF::Builder->new(-file => $pdfout);
 $page = $pdf->page();
@@ -381,7 +381,7 @@ is($example, $expected, 'multi-strip lzw (not converted to flate) without GT');
 
 # 18
 SKIP: {
-    skip "No 'convert' utility available, or no Graphics::TIFF.", 1 unless
+    skip "Either ImageMagick or Graphics::TIFF not available.", 1 unless
         defined $convert and $has_GT;
 
 # .png file is temporary file (output, input, erased)


### PR DESCRIPTION
This expands the tests run in the CI to three different runners:
- Linux with everything
- Linux without Graphics::TIFF
- Linux without Graphics::TIFF or Ghostscript

Once #158 is fixed, I'll add Windows runners with and without Imagemagick

Note that the Github Linux runner doesn't define default fonts in Imagemagick, so I had to add them explicitly in t/tiff. We may need a couple of iterations to find fonts that exist on Windows and in the Github Linux runner (or the Linux package with the missing fonts).