### PR TITLE
Full Windows test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,3 +46,16 @@ jobs:
       - run: cpan Font::TTF GD IO::Compress Test::Exception Test::Memory::Cycle
       - run: perl Makefile.PL
       - run: make test TEST_VERBOSE=1
+  full-windows:
+    name: Full Windows
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: choco install imagemagick dejavufonts ghostscript
+      - run: refreshenv
+      - run: echo "C:\strawberry\c\bin;C:\strawberry\perl\site\bin;C:\strawberry\perl\bin;C:\Program Files\ImageMagick-7.0.11-Q16-HDRI;C:\Program Files\gs\gs9.54.0\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+      - run: magick convert -version
+      - run: gswin64c -v
+      - run: cpan Font::TTF GD IO::Compress Test::Exception Test::Memory::Cycle Graphics::TIFF
+      - run: perl Makefile.PL
+      - run: make test TEST_VERBOSE=1

--- a/t/tiff.t
+++ b/t/tiff.t
@@ -105,9 +105,9 @@ my $pngout = File::Spec->catfile($directory, 'out.png');
 #   may have to do this manually
 
 my ($convert, $gs);
-# Linux-like systems usually have a pre-installed "convert" utility, while
-# Windows must use ImageMagick. In addition, be careful NOT to run "convert"
-# on Windows, as this is a HDD reformatter!
+# ImageMagick pre-v7 has a "convert" utility.
+# On v7, this is called via "magick convert"
+# On Windows, be careful NOT to run "convert", as this is a HDD reformatter!
 if      (can_run("magick")) {
     $convert = "magick convert";
 } elsif ($OSNAME ne 'MSWin32' and can_run("convert")) {
@@ -220,7 +220,7 @@ is($example, $expected, 'single-strip lzw (not converted to flate) with GT');
 
 # 12
 SKIP: {
-    skip "No 'convert' utility available, or no Graphics::TIFF.", 1 unless
+    skip "Either ImageMagick, Ghostscript or Graphics::TIFF not available.", 1 unless
         defined $convert and defined $gs and $has_GT;
 
 system("$convert -depth 1 -gravity center -pointsize 78 -size ${width}x${height} caption:\"A caption for the image\" -background white -alpha off -define tiff:rows-per-strip=50 -compress lzw $tiff_f");
@@ -245,7 +245,7 @@ is($example, $expected, 'multi-strip lzw (not converted to flate) with GT');
 
 # 13
 SKIP: {
-    skip "No 'convert' utility available, or no Graphics::TIFF.", 1 unless
+    skip "Either ImageMagick, Ghostscript or Graphics::TIFF not available.", 1 unless
         defined $convert and defined $gs and $has_GT;
 
 $width = 20;
@@ -272,7 +272,7 @@ is($example, $expected, 'lzw+horizontal predictor (not converted to flate) with 
 
 # 14
 SKIP: {
-    skip "No 'convert' utility available, or no Graphics::TIFF.", 1 unless
+    skip "Either ImageMagick, Ghostscript or Graphics::TIFF not available.", 1 unless
         defined $convert and defined $gs and $has_GT;
 
 $width = 1000;
@@ -324,7 +324,7 @@ is($example, $expected, 'single-strip lzw (not converted to flate) without GT');
 }
 
 SKIP: {
-    skip "No 'convert' utility available.", 1 unless
+    skip "Either ImageMagick or Ghostscript not available.", 1 unless
         defined $convert and defined $gs;
 
 # 16
@@ -409,7 +409,9 @@ sub check_version {
     # was the check routine already defined (installed)?
     if (defined $cmd) {
 	# should match dotted version number
-	if (`$cmd $arg` =~ m/$regex/) {
+        my $output = `$cmd $arg`;
+        diag($output);
+	if ($output =~ m/$regex/) {
 	    if (version->parse($1) >= version->parse($min_ver)) {
 		return $cmd;
 	    }


### PR DESCRIPTION
Finally got everything working in a Windows runner. It is a little brittle, because choco doesn't seem to update the `PATH` variable properly, so I had to do it manually, which means every time choco updates its imagemagick or ghostscript versions, the path will have to be adapted. However, the test should then fail immediately, which at least should highlight the fact that the workflow needs updating.

I've added some diagnostic messages so that it is clear whether Perl has found imagemagick or ghostscript or not.