### PR TITLE
Correct Windows ghostscript path for gs v9.55.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/checkout@v2
       - run: choco install imagemagick dejavufonts ghostscript
       - run: refreshenv
-      - run: echo "C:\strawberry\c\bin;C:\strawberry\perl\site\bin;C:\strawberry\perl\bin;C:\Program Files\ImageMagick-7.1.0-Q16-HDRI;C:\Program Files\gs\gs9.54.0\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+      - run: echo "C:\strawberry\c\bin;C:\strawberry\perl\site\bin;C:\strawberry\perl\bin;C:\Program Files\ImageMagick-7.1.0-Q16-HDRI;C:\Program Files\gs\gs9.55.0\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
       - run: magick convert -version
       - run: gswin64c -v
       - run: cpan Font::TTF GD IO::Compress Test::Exception Test::Memory::Cycle Graphics::TIFF


### PR DESCRIPTION
Ghostscript embeds the version number in the path, which had therefore changed, and it could therefore no longer be found. Obviously, this is really brittle, and there is probably a way of extracting the directory below C:\Program Files\gs\ and adding it to the path automatically.