### PR TITLE
tests: Add font paths on Fedora

### DIFF
--- a/t/font-synfont.t
+++ b/t/font-synfont.t
@@ -8,6 +8,7 @@ my $test_count = 2;
 use PDF::Builder;
 
 my @possible_locations = (
+    '/usr/share/fonts/dejavu-sans-fonts/DejaVuSans.ttf',
     '/usr/share/fonts/truetype/ttf-dejavu/DejaVuSans.ttf',
     '/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf',
     '/var/lib/defoma/gs.d/dirs/fonts/DejaVuSans.ttf',

--- a/t/font-ttf.t
+++ b/t/font-ttf.t
@@ -8,6 +8,7 @@ my $test_count = 2;
 use PDF::Builder;
 
 my @possible_locations = (
+    '/usr/share/fonts/dejavu-sans-fonts/DejaVuSans.ttf',
     '/usr/share/fonts/truetype/ttf-dejavu/DejaVuSans.ttf',
     '/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf',
     '/var/lib/defoma/gs.d/dirs/fonts/DejaVuSans.ttf',

--- a/t/font-type1.t
+++ b/t/font-type1.t
@@ -26,6 +26,8 @@ if ($OSname eq 'MSWin32') {
     # Unix/Linux systems assumed. is this a standard location everyone has?
     push @pfb_list, '/usr/share/fonts/type1/gsfonts/a010013l.pfb';
     push @pfm_list, '/usr/share/fonts/type1/gsfonts/a010013l.pfm';
+    push @pfb_list, '/usr/share/X11/fonts/urw-fonts/a010013l.pfb';
+    push @pfm_list, '/usr/share/X11/fonts/urw-fonts/a010013l.pfm';
 }
 
 # This may or may not work on Macs ("darwin" string) and other platforms


### PR DESCRIPTION
This commit add paths to font files used by font tests as found on Fedora systems.